### PR TITLE
Close always waits for zk connection to close

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -127,10 +127,10 @@ func (w *Watch) Event() <-chan struct{} {
 }
 
 // Close blocks until the underlying Zookeeper connection is closed.
-// If already called, will simply return, even if in the process of closing due to another call.
 func (w *Watch) Close() {
 	select {
 	case <-w.done:
+		w.wg.Wait()
 		return
 	default:
 	}


### PR DESCRIPTION
Previously only the first call would wait for the connection to close.
Now all calls to close will only return when the connection has closed.

FYI, @mlerner 