### PR TITLE
Balance at the Transport Level.

### DIFF
--- a/httpset/README.md
+++ b/httpset/README.md
@@ -25,29 +25,23 @@ Usage
 			log.Fatalf("Registration error: %v", err)
 		}
 
-		cluster := httpset.New(watch)
-		cluster.UseHTTPS = true  // if scheme not specified, will use https
+		t := httpset.NewTransport(watch)
+		t.UseHTTPS = true  // if scheme not specified, will use https
 
-		// can make requests using the standard net/http methods
-		resp, err = cluster.Do(req)
+		client := &http.Client{
+			Transport: t,
+		}
 
-		// use just the path and the hostname will be added
-		// scheme will be http or https depending on cluster.UseHTTPS
-		resp, err = cluster.Get("/some/path")
-
-		// or use a complete url and only the hostname will be swapped
-		resp, err = cluster.Head(http://somehost.com/some/path)
-
-		resp, err = cluster.Post(url, bodyType, body)
-		resp, err = cluster.PostForm(url)
-
-	    // the hostnames of these requests are replaces with those in the serverset
-	    // in a round-robin fashion.
+		// Use the client as you normally would.
 	}
 
 Dependencies
 ------------
-* [github.com/strava/go.serversets](github.com/strava/go.serversets) to get the server list
+* [github.com/strava/go.serversets](github.com/strava/go.serversets) to get the server list.
+However, one can use a predefined set of servers by doing something like:
+
+		t := httpset.NewTransport(nil)
+		t.SetEndpoints([]string{"server1.com", "server2.com"})
 
 Potential Improvements and Contributing
 ---------------------------------------

--- a/httpset/httpset.go
+++ b/httpset/httpset.go
@@ -2,11 +2,7 @@ package httpset
 
 import (
 	"errors"
-	"io"
 	"net/http"
-	"net/url"
-	"sync/atomic"
-	"time"
 )
 
 var (
@@ -22,198 +18,21 @@ type Watcher interface {
 }
 
 // A HTTPSet is a wrapper around the serverset.Watch to handle making requests to a set of servers.
-// The same net/http Do, Get, Head, Post and PostForm methods are provided with just the
-// the host replaces with one from the list. Servers are picked in a simple round-robin fashion.
+// It encapsulates a http.Client using a httpset.Transport that does all the balancing.
+// This object is DEPRECATED, one should use Transport and build their own http.Clients.
 type HTTPSet struct {
-	Watcher
-
-	// The underlying client to use. Will default to the http.DefaultClient
-	HTTPClient *http.Client
-	UseHTTPS   bool // if scheme not specified, will use https
-
-	LastEvent  time.Time
-	EventCount int
-
-	// This channel will get an event when zookeeper updates things
-	// calling SetEndpoints will not trigger this type of event.
-	event     chan struct{}
-	count     int64
-	endpoints []string
+	*Transport
+	*http.Client
 }
 
 // New creates a new set of http clients backed by the serverset.
-// Can be used to round robin over a set of servers by having watch = nil
-// and then calling SetEndpoints with the known set of hosts.
+// This object is DEPRECATED, one should use Transport and build their own http.Clients.
 func New(watch Watcher) *HTTPSet {
-	httpset := &HTTPSet{
-		Watcher:    watch,
-		HTTPClient: http.DefaultClient,
-		event:      make(chan struct{}, 1),
-	}
-
-	if watch != nil {
-		// don't trigger and event the first time
-		httpset.setEndpoints(watch.Endpoints())
-
-		go func() {
-			for {
-				select {
-				case <-watch.Event():
-					httpset.SetEndpoints(watch.Endpoints())
-				}
-
-				if watch.IsClosed() {
-					break
-				}
-			}
-
-			watcherClosed()
-		}()
-	}
-
-	return httpset
-}
-
-// for use during testing. Saw this in the net/http standard lib.
-var watcherClosed = func() {}
-
-// Do sends an HTTP request to one of the hosts at one of the hosts in the serverset.
-// This function behaves the same as the same function in the net/http library,
-// but updates the URL.Host to a endpoint (host:port) from the list.
-// The hosts are picked in a round-robin fashion.
-func (s *HTTPSet) Do(req *http.Request) (*http.Response, error) {
-	host, err := s.RotateEndpoint()
-	if err != nil {
-		return nil, err
-	}
-
-	req.URL.Host = host
-	return s.HTTPClient.Do(req)
-}
-
-// Get issues a GET to the specified URL at one of the hosts in the serverset.
-// This function behaves the same as the same function in the net/http library,
-// but updates the URL.Host to a endpoint (host:port) from the list.
-// The hosts are picked in a round-robin fashion.
-func (s *HTTPSet) Get(url string) (*http.Response, error) {
-	url, err := s.replaceHost(url)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.HTTPClient.Get(url)
-}
-
-// Head issues a HEAD to the specified URL at one of the hosts in the serverset.
-// This function behaves the same as the same function in the net/http library,
-// but updates the URL.Host to a endpoint (host:port) from the list.
-// The hosts are picked in a round-robin fashion.
-func (s *HTTPSet) Head(url string) (*http.Response, error) {
-	url, err := s.replaceHost(url)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.HTTPClient.Head(url)
-}
-
-// Post issues a POST to the specified URL at one of the hosts in the serverset.
-// This function behaves the same as the same function in the net/http library,
-// but updates the URL.Host to a endpoint (host:port) from the list.
-// The hosts are picked in a round-robin fashion.
-func (s *HTTPSet) Post(url string, bodyType string, body io.Reader) (*http.Response, error) {
-	url, err := s.replaceHost(url)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.HTTPClient.Post(url, bodyType, body)
-}
-
-// PostForm issues a POST to the specified URL at one of the hosts in the serverset.
-// This function behaves the same as the same function in the net/http library,
-// but updates the URL.Host to a endpoint (host:port) from the list.
-// The hosts are picked in a round-robin fashion.
-func (s *HTTPSet) PostForm(url string, data url.Values) (*http.Response, error) {
-	url, err := s.replaceHost(url)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.HTTPClient.PostForm(url, data)
-}
-
-// replaceHost replaces the host in the raw url with one from the current list of endpoints.
-func (s *HTTPSet) replaceHost(rawurl string) (string, error) {
-	u, err := url.Parse(rawurl)
-	if err != nil {
-		return "", err
-	}
-
-	host, err := s.RotateEndpoint()
-	if err != nil {
-		return "", err
-	}
-	u.Host = host
-	if u.Scheme == "" {
-		if s.UseHTTPS {
-			u.Scheme = "https"
-		} else {
-			u.Scheme = "http"
-		}
-	}
-
-	return u.String(), nil
-}
-
-// Endpoints returns the current endpoints for this service.
-// This can be those set via the serverset.Watch or manually via SetEndpoints()
-func (s *HTTPSet) Endpoints() []string {
-	return s.endpoints
-}
-
-// Event returns the event channel. This channel will get an object
-// whenever something changes with the list of endpoints.
-// Mostly just a passthrough of the underlying watch event.
-func (s *HTTPSet) Event() <-chan struct{} {
-	return s.event
-}
-
-// SetEndpoints sets current list of endpoints. This will override the list
-// returned by the serverset. An event by the serverset will override these values.
-// This should be used to take advantage of the round robin features of this library without a serverset.Watch.
-func (s *HTTPSet) SetEndpoints(endpoints []string) {
-	s.setEndpoints(endpoints)
-	s.triggerEvent()
-}
-
-func (s *HTTPSet) setEndpoints(endpoints []string) {
-	// copy the contents,
-	// just to be triple sure an external client won't mess with stuff.
-	eps := make([]string, len(endpoints), len(endpoints))
-	copy(eps, endpoints)
-
-	s.endpoints = eps
-}
-
-// RotateEndpoint returns host:port for the endpoints in a round-robin fashion.
-func (s *HTTPSet) RotateEndpoint() (string, error) {
-	if len(s.endpoints) == 0 {
-		return "", ErrNoServers
-	}
-
-	c := atomic.AddInt64(&s.count, 1)
-	eps := s.endpoints
-	return eps[c%int64(len(eps))], nil
-}
-
-// triggerEvent, will queue up something in the Event channel if there isn't already something there.
-func (s *HTTPSet) triggerEvent() {
-	s.EventCount++
-	s.LastEvent = time.Now()
-
-	select {
-	case s.event <- struct{}{}:
-	default:
+	transport := NewTransport(watch)
+	return &HTTPSet{
+		Transport: transport,
+		Client: &http.Client{
+			Transport: transport,
+		},
 	}
 }

--- a/httpset/httpset_test.go
+++ b/httpset/httpset_test.go
@@ -1,6 +1,9 @@
 package httpset
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/strava/go.serversets/fixedset"
@@ -22,88 +25,38 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestCloseWatch(t *testing.T) {
-	count := 0
-	event := make(chan struct{}, 1)
-	watcherClosed = func() {
-		count++
-		event <- struct{}{}
+func TestHTTPSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
 	}
 
-	fs := fixedset.New(nil)
-	New(fs)
+	count1 := 0
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count1++
+	}))
+	defer server1.Close()
 
-	fs.Close()
+	count2 := 0
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count2++
+	}))
+	defer server2.Close()
 
-	// little event channel to allow the other goroutine to run and quit as it should
-	<-event
-	if count != 1 {
-		t.Error("should close watching goroutine on watcher channel close")
-	}
-}
+	set := New(nil)
 
-func TestNewWithoutWatcher(t *testing.T) {
-	New(nil)
-	// should not panic or anything
-}
+	u1, _ := url.Parse(server1.URL)
+	u2, _ := url.Parse(server2.URL)
 
-func TestHTTPSetReplaceHost(t *testing.T) {
-	httpset := New(nil)
-	_, err := httpset.replaceHost("http://hostname/path/path2")
-	if err != ErrNoServers {
-		t.Errorf("should get error, but got %v", err)
-	}
+	set.SetEndpoints([]string{u1.Host, u2.Host})
+	<-set.Event()
 
-	httpset.SetEndpoints([]string{"host:123"})
-
-	tests := [][2]string{
-		[2]string{"http://hostname/path/path2", "http://host:123/path/path2"},
-		[2]string{"http://hostname:321/path/path2", "http://host:123/path/path2"},
-		[2]string{"https://hostname:321/path/path2", "https://host:123/path/path2"},
-		[2]string{"https://hostname:321/path/path2?key=value", "https://host:123/path/path2?key=value"},
-		[2]string{"/path/path2?key=value", "http://host:123/path/path2?key=value"},
+	set.Get("http://somehost/")
+	if count2 != 1 {
+		t.Errorf("should hit the second server, got %v", count2)
 	}
 
-	for _, test := range tests {
-		answer, _ := httpset.replaceHost(test[0])
-		if test[1] != answer {
-			t.Errorf("host not replaced, expected %s, got %s", test[0], answer)
-		}
-	}
-
-	// UseHTTPS
-	httpset.UseHTTPS = true
-	answer, _ := httpset.replaceHost("/path/path2?key=value")
-	if answer != "https://host:123/path/path2?key=value" {
-		t.Errorf("host not replaced, got %s", answer)
-	}
-}
-
-func TestHTTPSetRotateServer(t *testing.T) {
-	httpset := New(nil)
-	httpset.SetEndpoints([]string{"localhost:2181", "localhost:2182"})
-
-	if ep, _ := httpset.RotateEndpoint(); ep != "localhost:2182" {
-		t.Errorf("incorrect server, got %v", ep)
-	}
-
-	if ep, _ := httpset.RotateEndpoint(); ep != "localhost:2181" {
-		t.Errorf("incorrect server, got %v", ep)
-	}
-
-	if ep, _ := httpset.RotateEndpoint(); ep != "localhost:2182" {
-		t.Errorf("incorrect server, got %v", ep)
-	}
-}
-
-func TestHTTPSetTriggerEvent(t *testing.T) {
-	httpset := New(nil)
-
-	httpset.triggerEvent()
-	httpset.triggerEvent()
-	httpset.triggerEvent()
-
-	if httpset.EventCount != 3 {
-		t.Errorf("event count not right, got %v", httpset.EventCount)
+	set.Head("http://somehost/")
+	if count1 != 1 {
+		t.Errorf("should hit the first server, got %v", count1)
 	}
 }

--- a/httpset/transport.go
+++ b/httpset/transport.go
@@ -1,0 +1,147 @@
+package httpset
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// Transport implements the http.RoundTripper interface loadbalancing
+// over a set of hosts.
+type Transport struct {
+	Watcher
+
+	UseHTTPS bool // if scheme not specified, will use https
+
+	// BaseTransport is what's used after the url is rewritten to the correct host.
+	// If not set, http.DefaultTransport will be used.
+	BaseTransport http.RoundTripper
+
+	LastEvent  time.Time
+	EventCount int
+
+	event     chan struct{}
+	count     int64
+	endpoints []string
+}
+
+// NewTransport creates a new Transport given the server set.
+// Pass in nil and use SetEndpoints to balance over a fixed set of endpoints.
+func NewTransport(watch Watcher) *Transport {
+	t := &Transport{
+		Watcher: watch,
+		event:   make(chan struct{}, 1),
+	}
+
+	if watch != nil {
+		// don't trigger an event the first time
+		t.setEndpoints(watch.Endpoints())
+
+		go func() {
+			for {
+				select {
+				case <-watch.Event():
+					t.SetEndpoints(watch.Endpoints())
+				}
+
+				if watch.IsClosed() {
+					break
+				}
+			}
+
+			watcherClosed()
+		}()
+	}
+
+	return t
+}
+
+// for use during testing. Saw this in the net/http standard lib.
+var watcherClosed = func() {}
+
+// RoundTrip is here to implement the http.RoundTripper interface so this
+// can be used as Transport for an http.Client. It simply rewrites the host
+// and passit it to http.DefaultTransport or t.BaseTransport if defined.
+// The default transport does it's own connection pooling based on hostname.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	err := t.replaceHost(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if t.BaseTransport == nil {
+		return http.DefaultTransport.RoundTrip(req)
+	}
+
+	return t.BaseTransport.RoundTrip(req)
+}
+
+func (t *Transport) replaceHost(req *http.Request) error {
+	host, err := t.RotateEndpoint()
+	if err != nil {
+		return err
+	}
+
+	req.URL.Host = host
+	if req.URL.Scheme == "" {
+		if t.UseHTTPS {
+			req.URL.Scheme = "https"
+		} else {
+			req.URL.Scheme = "http"
+		}
+	}
+
+	return nil
+}
+
+// Endpoints returns the current endpoints for this service.
+// This can be those set via the serverset.Watch or manually via SetEndpoints()
+func (t *Transport) Endpoints() []string {
+	return t.endpoints
+}
+
+// Event returns the event channel. This channel will get an object
+// whenever something changes with the list of endpoints.
+// Mostly just a passthrough of the underlying watch event and used for testing.
+func (t *Transport) Event() <-chan struct{} {
+	return t.event
+}
+
+// SetEndpoints sets current list of endpoints. This will override the list
+// returned by the serverset. An event by the serverset will override these values.
+// This should be used to take advantage of the round robin features of this library without a serverset.Watch.
+func (t *Transport) SetEndpoints(endpoints []string) {
+	t.setEndpoints(endpoints)
+	t.triggerEvent()
+}
+
+func (t *Transport) setEndpoints(endpoints []string) {
+	// copy the contents,
+	// just to be triple sure an external client won't mess with stuff.
+	eps := make([]string, len(endpoints), len(endpoints))
+	copy(eps, endpoints)
+
+	t.endpoints = eps
+}
+
+// RotateEndpoint returns host:port for the endpoints in a round-robin fashion.
+func (t *Transport) RotateEndpoint() (string, error) {
+	if len(t.endpoints) == 0 {
+		return "", ErrNoServers
+	}
+
+	c := atomic.AddInt64(&t.count, 1)
+	eps := t.endpoints
+	return eps[c%int64(len(eps))], nil
+}
+
+// triggerEvent, will queue up something in the Event channel if there isn't already something there.
+func (t *Transport) triggerEvent() {
+	t.EventCount++
+	t.LastEvent = time.Now()
+
+	select {
+	case t.event <- struct{}{}:
+	default:
+	}
+}

--- a/httpset/transport_test.go
+++ b/httpset/transport_test.go
@@ -1,0 +1,200 @@
+package httpset
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/strava/go.serversets/fixedset"
+)
+
+type StubRoundTripper struct {
+	PrevRequest *http.Request
+}
+
+func (rt *StubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.PrevRequest = req
+	return nil, nil
+}
+
+func TestNewTransport(t *testing.T) {
+	fs := fixedset.New([]string{"localhost:2181"})
+	transport := NewTransport(fs)
+	if l := len(transport.Endpoints()); l != 1 {
+		t.Errorf("should have one endpoint but got %v", l)
+	}
+
+	fs.SetEndpoints([]string{"localhost:2181", "localhost:2182"})
+
+	<-transport.Event()
+	if len(transport.Endpoints()) != 2 {
+		t.Errorf("should have two endpoint but got %v", transport.Endpoints())
+	}
+}
+
+func TestTransportRoundTrip(t *testing.T) {
+	transport := NewTransport(nil)
+	stub := &StubRoundTripper{}
+	transport.BaseTransport = stub
+
+	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	_, err := transport.RoundTrip(r)
+	if err != ErrNoServers {
+		t.Errorf("should get error if no servers")
+	}
+
+	transport.SetEndpoints([]string{"a:80", "b:80"})
+	<-transport.Event()
+
+	r, _ = http.NewRequest("GET", "http://localhost", nil)
+	transport.RoundTrip(r)
+	if v := stub.PrevRequest.URL.String(); v != "http://b:80" {
+		t.Errorf("incorrect url, got %v", v)
+	}
+
+	transport.RoundTrip(r)
+	if v := stub.PrevRequest.URL.String(); v != "http://a:80" {
+		t.Errorf("incorrect url, got %v", v)
+	}
+
+	transport.RoundTrip(r)
+	if v := stub.PrevRequest.URL.String(); v != "http://b:80" {
+		t.Errorf("incorrect url, got %v", v)
+	}
+}
+
+func TestTransportCloseWatch(t *testing.T) {
+	count := 0
+	event := make(chan struct{}, 1)
+	watcherClosed = func() {
+		count++
+		event <- struct{}{}
+	}
+
+	fs := fixedset.New(nil)
+	NewTransport(fs)
+
+	fs.Close()
+
+	// little event channel to allow the other goroutine to run and quit as it should
+	<-event
+	if count != 1 {
+		t.Error("should close watching goroutine on watcher channel close")
+	}
+}
+
+func TestNewTransportWithoutWatcher(t *testing.T) {
+	NewTransport(nil)
+	// should not panic or anything
+}
+
+func TestTransportRotateServer(t *testing.T) {
+	transport := NewTransport(nil)
+	transport.SetEndpoints([]string{"localhost:2181", "localhost:2182"})
+
+	if ep, _ := transport.RotateEndpoint(); ep != "localhost:2182" {
+		t.Errorf("incorrect server, got %v", ep)
+	}
+
+	if ep, _ := transport.RotateEndpoint(); ep != "localhost:2181" {
+		t.Errorf("incorrect server, got %v", ep)
+	}
+
+	if ep, _ := transport.RotateEndpoint(); ep != "localhost:2182" {
+		t.Errorf("incorrect server, got %v", ep)
+	}
+}
+
+func TestTransportTriggerEvent(t *testing.T) {
+	transport := NewTransport(nil)
+
+	transport.triggerEvent()
+	transport.triggerEvent()
+	transport.triggerEvent()
+
+	if transport.EventCount != 3 {
+		t.Errorf("event count not right, got %v", transport.EventCount)
+	}
+}
+
+func TestTransportReplaceHost(t *testing.T) {
+	transport := NewTransport(nil)
+
+	r, _ := http.NewRequest("GET", "http://hostname/path/path2", nil)
+	err := transport.replaceHost(r)
+	if err != ErrNoServers {
+		t.Errorf("should get error, but got %v", err)
+	}
+
+	transport.SetEndpoints([]string{"host:123"})
+	tests := [][2]string{
+		[2]string{"http://hostname/path/path2", "http://host:123/path/path2"},
+		[2]string{"http://hostname:321/path/path2", "http://host:123/path/path2"},
+		[2]string{"https://hostname:321/path/path2", "https://host:123/path/path2"},
+		[2]string{"https://hostname:321/path/path2?key=value", "https://host:123/path/path2?key=value"},
+		[2]string{"/path/path2?key=value", "http://host:123/path/path2?key=value"},
+	}
+
+	for _, test := range tests {
+		r, _ := http.NewRequest("GET", test[0], nil)
+		transport.replaceHost(r)
+		if v := r.URL.String(); v != test[1] {
+			t.Errorf("host not replaced, expected %s, got %s", test[1], v)
+		}
+	}
+
+	// UseHTTPS
+	transport.UseHTTPS = true
+	r, _ = http.NewRequest("GET", "/path/path2?key=value", nil)
+	transport.replaceHost(r)
+
+	if v := r.URL.String(); v != "https://host:123/path/path2?key=value" {
+		t.Errorf("host not replaced, got %s", v)
+	}
+}
+
+func TestTransport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	count1 := 0
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count1++
+	}))
+	defer server1.Close()
+
+	count2 := 0
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count2++
+	}))
+	defer server2.Close()
+
+	transport := NewTransport(nil)
+
+	u1, _ := url.Parse(server1.URL)
+	u2, _ := url.Parse(server2.URL)
+
+	transport.SetEndpoints([]string{u1.Host, u2.Host})
+	<-transport.Event()
+
+	r, _ := http.NewRequest("GET", "http://somehost/", nil)
+	_, err := transport.RoundTrip(r)
+	if err != nil {
+		t.Errorf("request error: %v", err)
+	}
+
+	if count2 != 1 {
+		t.Errorf("should hit the second server, got %v", count2)
+	}
+
+	_, err = transport.RoundTrip(r)
+	if err != nil {
+		t.Errorf("request error: %v", err)
+	}
+
+	if count1 != 1 {
+		t.Errorf("should hit the first server, got %v", count1)
+	}
+}


### PR DESCRIPTION
Previous implementation was dump. This creates a new object `Transport` that implements `http.RoundTripper` to do the balancing. This creates one choke point for updating the host and is a lot cleaner.

Transport still rewrites the host and passes it to the http.DefaultTransport by default. This transport does its own connection pooling by host:port.

Alternately one could do the balancing at the TCP dial level but this would mess with the http package’s internal balancing allowing its idle pool to potentially contain connections to just one of the hosts.

@mlerner 