### PR TITLE
Attempt to make consistent hashing more uniform

### DIFF
--- a/mcset/consistent/consistent.go
+++ b/mcset/consistent/consistent.go
@@ -236,13 +236,17 @@ func (c *Consistent) GetN(name string, n int) ([]string, error) {
 	return res, nil
 }
 
+var t = crc32.MakeTable(crc32.Castagnoli)
+
 func (c *Consistent) hashKey(key string) uint32 {
-	if len(key) < 64 {
-		var scratch [64]byte
+	if len(key) < 128 {
+		var scratch [128]byte
 		copy(scratch[:], key)
-		return crc32.ChecksumIEEE(scratch[:len(key)])
+
+		return crc32.Checksum(scratch[:len(key)], t)
 	}
-	return crc32.ChecksumIEEE([]byte(key))
+
+	return crc32.Checksum([]byte(key), t)
 }
 
 func (c *Consistent) updateSortedHashes() {

--- a/mcset/consistent/consistent_test.go
+++ b/mcset/consistent/consistent_test.go
@@ -96,9 +96,9 @@ type gtest struct {
 }
 
 var gmtests = []gtest{
-	{"ggg", "abcdefg"},
+	{"ggg", "hijklmn"},
 	{"hhh", "opqrstu"},
-	{"iiiii", "hijklmn"},
+	{"iiiii", "opqrstu"},
 }
 
 func TestGetMultiple(t *testing.T) {
@@ -137,9 +137,9 @@ func TestGetMultipleQuick(t *testing.T) {
 }
 
 var rtestsBefore = []gtest{
-	{"ggg", "abcdefg"},
+	{"ggg", "hijklmn"},
 	{"hhh", "opqrstu"},
-	{"iiiii", "hijklmn"},
+	{"iiiii", "opqrstu"},
 }
 
 var rtestsAfter = []gtest{
@@ -305,13 +305,13 @@ func TestGetN(t *testing.T) {
 	if len(members) != 3 {
 		t.Errorf("expected 3 members instead of %d", len(members))
 	}
-	if members[0] != "opqrstu" {
+	if members[0] != "abcdefg" {
 		t.Errorf("wrong members[0]: %q", members[0])
 	}
-	if members[1] != "abcdefg" {
+	if members[1] != "hijklmn" {
 		t.Errorf("wrong members[1]: %q", members[1])
 	}
-	if members[2] != "hijklmn" {
+	if members[2] != "opqrstu" {
 		t.Errorf("wrong members[2]: %q", members[2])
 	}
 }
@@ -348,13 +348,13 @@ func TestGetNMore(t *testing.T) {
 	if len(members) != 3 {
 		t.Errorf("expected 3 members instead of %d", len(members))
 	}
-	if members[0] != "opqrstu" {
+	if members[0] != "abcdefg" {
 		t.Errorf("wrong members[0]: %q", members[0])
 	}
-	if members[1] != "abcdefg" {
+	if members[1] != "hijklmn" {
 		t.Errorf("wrong members[1]: %q", members[1])
 	}
-	if members[2] != "hijklmn" {
+	if members[2] != "opqrstu" {
 		t.Errorf("wrong members[2]: %q", members[2])
 	}
 }
@@ -730,7 +730,7 @@ func TestConcurrentGetSet(t *testing.T) {
 				if err != nil {
 					t.Error(err)
 				}
-				if a != "def" && a != "vwx" {
+				if a != "mno" && a != "pqr" {
 					t.Errorf("got %s, expected abc", a)
 				}
 				time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)

--- a/mcset/consistent/example_test.go
+++ b/mcset/consistent/example_test.go
@@ -26,9 +26,9 @@ func ExampleNew() {
 	}
 	// Output:
 	// user_mcnulty => cacheA
-	// user_bunk => cacheA
-	// user_omar => cacheA
-	// user_bunny => cacheC
+	// user_bunk => cacheB
+	// user_omar => cacheC
+	// user_bunny => cacheB
 	// user_stringer => cacheC
 }
 
@@ -63,7 +63,7 @@ func ExampleAdd() {
 	// user_omar => cacheA
 	// user_bunny => cacheC
 	// user_stringer => cacheC
-	//
+
 	// with cacheD, cacheE [A, B, C, D, E]
 	// user_mcnulty => cacheE
 	// user_bunk => cacheA
@@ -97,16 +97,16 @@ func ExampleRemove() {
 	}
 	// Output:
 	// initial state [A, B, C]
-	// user_mcnulty => cacheA
-	// user_bunk => cacheA
-	// user_omar => cacheA
-	// user_bunny => cacheC
-	// user_stringer => cacheC
-	//
+	// user_mcnulty => cacheC
+	// user_bunk => cacheB
+	// user_omar => cacheB
+	// user_bunny => cacheA
+	// user_stringer => cacheB
+
 	// cacheC removed [A, B]
 	// user_mcnulty => cacheA
-	// user_bunk => cacheA
-	// user_omar => cacheA
-	// user_bunny => cacheB
+	// user_bunk => cacheB
+	// user_omar => cacheB
+	// user_bunny => cacheA
 	// user_stringer => cacheB
 }

--- a/mcset/mcset.go
+++ b/mcset/mcset.go
@@ -51,6 +51,8 @@ func New(watch Watcher) *MCSet {
 		consistent: consistent.New(),
 	}
 
+	mcset.consistent.NumberOfReplicas = 100
+
 	if watch != nil {
 		// first time don't trigger an event
 		mcset.setEndpoints(watch.Endpoints())


### PR DESCRIPTION
[This code](https://gist.github.com/paulmach/74bc0a2df4b71bd8d0da) runs rand strings against the consistent hash function and checks uniformity. Unfortunately the results are not even close to uniform:
```
  58856	10.0.16.69:11211
  18389	10.0.22.188:11211
  22755	10.0.26.214:11211
```
This is matches what we're seeing in production (memcache load is not uniform and matches the distribution above). The issue is due to the non-uniformity of the crc32 hash function. :(

So I updated to use a different hash table as well as to default to more replicas on the consistent hash "ring". This gave better results, but I was unable to find something that would be better for all inputs
```
  29161	10.0.16.69:11211
  37910	10.0.22.188:11211
  32929	10.0.26.214:11211
```

@mlerner 
