### PR TITLE
Handle missing node on watch event.

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -101,7 +101,7 @@ func (ss *ServerSet) Watch() (*Watch, error) {
 
 				watch.endpoints, err = watch.updateEndpoints(connection, keys)
 				if err != nil {
-					panic(fmt.Errorf("unable to reregister endpoint after session expired: %v", err))
+					panic(fmt.Errorf("unable to update endpoint list after session expired: %v", err))
 				}
 
 				watch.triggerEvent()
@@ -176,7 +176,12 @@ func (w *Watch) updateEndpoints(connection *zk.Conn, keys []string) ([]string, e
 		}
 
 		data, _, err := connection.Get(w.serverSet.directoryPath() + "/" + k)
-		if err != nil && err != zk.ErrNoNode {
+		if err == zk.ErrNoNode {
+			continue
+		}
+
+		if err != nil {
+			// most likely some sort of zk connection error
 			return nil, err
 		}
 

--- a/watch_test.go
+++ b/watch_test.go
@@ -45,6 +45,38 @@ func TestWatchSortEndpoints(t *testing.T) {
 	}
 }
 
+func TestWatchUpdateEndpoints(t *testing.T) {
+	set := New(Test, "gotest", []string{TestServer})
+
+	watch, err := set.Watch()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watch.Close()
+
+	ep1, err := set.RegisterEndpoint("localhost", 1002, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ep1.Close()
+	<-watch.Event()
+
+	conn, _, err := set.connectToZookeeper()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	eps, err := watch.updateEndpoints(conn, []string{MemberPrefix + "random"})
+	if err != nil {
+		t.Fatalf("should not have error, got %v", err)
+	}
+
+	if len(eps) != 0 {
+		t.Errorf("should not have any endpoints, got %v", eps)
+	}
+}
+
 func TestWatchIsClosed(t *testing.T) {
 	set := New(Test, "gotest", []string{TestServer})
 	watch, err := set.Watch()


### PR DESCRIPTION
When things change, a watch will be reset on the parent node and its
children. This process returns the set of child keys. Right after,
those keys are check for their values sequentially, to update the
endpoints list. It is possible, while the children are being checked,
one of them disappears. This case is now handled properly.

@mlerner @drewrobb 