### PR TITLE
add thriftset thrift server balancing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - cd ../..
 
 install:
+  - go get github.com/strava/go.statsd
   - go get github.com/apache/thrift/lib/go/thrift
 
 script:

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@ go.serversets [![Build Status](https://travis-ci.org/strava/go.serversets.png?br
 =============
 
 Package **go.serversets** provides an simple interface for service discovery using [Apache Zookeeper](http://zookeeper.apache.org/).
-Servers/endpoints register themselves and clients always have an updated host list. 
+Servers/endpoints register themselves and clients always have an updated host list.
 
-This core package just provides a list of hostnames and ports. Sub-packages wrap 
+This core package just provides a list of hostnames and ports. Sub-packages wrap
 the endpoint list for common use cases:
 
 * [mcset](/mcset) provides consistent hashing over a set of memcache hosts.
 * [httpset](/httpset) round-robins standard HTTP requests to the set of hosts.
 * [fixedset](/fixedset) severset watch without the zookeeper. Take advantage of
-the load balancing packages without the zookeeper discovery.
+* [thriftset](/thriftset) does "least request" load balancing around the given endpoints.
 
-This package is used internally at [Strava](http://strava.com) for 
-[Finagle](https://twitter.github.io/finagle/) service discovery and memcache node registration. 
+This package is used internally at [Strava](http://strava.com) for
+[Finagle](https://twitter.github.io/finagle/) service discovery and memcache node registration.
 
 Usage
 -----
@@ -29,7 +29,7 @@ Available environment constants: `serversets.Local`, `serversets.Staging`, `serv
 ### Register an Endpoint
 
 Service endpoints/producers/servers should register themselves as an endpoint. Example:
-	
+
 	pingFunction := func() error {
 		return nil
 	}
@@ -39,7 +39,7 @@ Service endpoints/producers/servers should register themselves as an endpoint. E
 		servicePort,
 		pingFunction)
 
-The ping function can be `nil`. But if it's not, it'll be checked every second, by default. If there is an 
+The ping function can be `nil`. But if it's not, it'll be checked every second, by default. If there is an
 error the endpoint will be unregistered. Once the issue is resolved it'll be reregistered automatically.
 This allows for registering external processes that may fail independently of the monitoring process.
 
@@ -87,7 +87,7 @@ use of these packages.
 
 Tests
 -----
-Tests require a Zookeeper server. The default is "localhost" but a different 
+Tests require a Zookeeper server. The default is "localhost" but a different
 host can be used by changing the `TestServer` variable in [serverset_test.go](serverset_test.go)
 
 	go test github.com/strava/go.serversets/...
@@ -95,6 +95,6 @@ host can be used by changing the `TestServer` variable in [serverset_test.go](se
 Potential Improvements and Contributing
 ---------------------------------------
 This library simply provides a list of active endpoints. But it would nice if it did some
-load balancing, error checking, retries etc. Simple versions of this are available for 
-[memcache](/mcset) and [http](/httpset) but they can be improved. 
+load balancing, error checking, retries etc. Simple versions of this are available for
+[memcache](/mcset) and [http](/httpset) but they can be improved.
 So, if you have some ideas, submit a pull request.

--- a/internal/endpoints/README.md
+++ b/internal/endpoints/README.md
@@ -1,0 +1,11 @@
+internal/endpoints
+==================
+
+Package **endpoints** is an internal package that tries to abstract
+the concept of a set of endpoints each with their own connection pool.
+
+It currently only does "least active requests" load balancing. It would be nice to extend this
+and add support for marking endpoints as down temporarily if there are issues.
+
+Right now only the `thriftset` package uses this code, but it would be interesting to
+implement a "least active requests" http load balancer using this code.

--- a/internal/endpoints/conn.go
+++ b/internal/endpoints/conn.go
@@ -1,0 +1,40 @@
+package endpoints
+
+import (
+	"io"
+	"time"
+)
+
+// A Conn represents a connection to an endpoint.
+type Conn struct {
+	ep       *endpoint
+	Endpoint string
+
+	// Conn is the item created by a Set.OpenSocket(host) call.
+	Conn io.Closer
+
+	// Data can be uses to store other info on the connection.
+	// Used by the thriftset to store protocol and transport factories.
+	Data interface{}
+}
+
+// Close on this connection calls close on the underlying connection/closer.
+func (c *Conn) Close() error {
+	return c.ep.RemoveAndClose(c)
+}
+
+// Release puts the connection back in the pool and allows others to use it.
+func (c *Conn) Release() error {
+
+	// TODO: this will return an error if the connection failed to be closed. Is that what we want?
+	return c.ep.ReturnConn(c)
+}
+
+type idleConn struct {
+	conn      *Conn
+	lastUsage time.Time
+}
+
+func (ic idleConn) Close() error {
+	return ic.conn.ep.RemoveAndClose(ic.conn)
+}

--- a/internal/endpoints/endpoint.go
+++ b/internal/endpoints/endpoint.go
@@ -1,0 +1,228 @@
+package endpoints
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// An endpoint contains the active and idle connection pools to the host.
+type endpoint struct {
+	Pooler Pooler
+	host   string
+	active int
+
+	lock sync.RWMutex
+	cond *sync.Cond
+
+	idle *list.List
+	done chan struct{}
+}
+
+// New creates a new endpoint for the given set and hostname.
+func newEndpoint(pooler Pooler, host string) *endpoint {
+	return &endpoint{
+		Pooler: pooler,
+		host:   host,
+		idle:   list.New(),
+		done:   make(chan struct{}),
+	}
+}
+
+// Host returns the host (ip or domain) this endpoint represents.
+func (ep *endpoint) Host() string {
+	return ep.host
+}
+
+// GetConn will create a connection or return one from the idle list.
+func (ep *endpoint) GetConn() (*Conn, error) {
+	if ep.IsClosed() {
+		return nil, ErrGetOnClosedEndpoint
+	}
+
+	// close stale connections
+	if timeout := ep.Pooler.IdleTimeout(); timeout > 0 {
+		ep.closeIdleConn(time.Now().Add(-timeout))
+	}
+
+	ep.lock.Lock()
+	for {
+		// try to get a connection from the idle list.
+		for i, n := 0, ep.idle.Len(); i < n; i++ {
+			elm := ep.idle.Front()
+			if elm == nil {
+				break
+			}
+
+			idled := elm.Value.(idleConn)
+			ep.idle.Remove(elm)
+
+			ep.active++
+			ep.lock.Unlock()
+			return idled.conn, nil
+		}
+
+		// Check for pool closed before dialing a new connection.
+		if ep.IsClosed() {
+			ep.lock.Unlock()
+			return nil, ErrGetOnClosedEndpoint
+		}
+
+		// create a new connection if under limit.
+		if maph := ep.Pooler.MaxActivePerHost(); maph == 0 || ep.active < maph {
+			ep.active++
+			ep.lock.Unlock()
+			return ep.newConn()
+		}
+
+		if ep.cond == nil {
+			ep.cond = sync.NewCond(&ep.lock)
+		}
+
+		// wait for a signal from a close event or a release event.
+		// This will unlock the lock and relock it once it returns. See sync.Cond docs.
+		ep.cond.Wait()
+	}
+}
+
+// ActiveConnections returns the number of connections current in use.
+func (ep *endpoint) ActiveConnections() int {
+	ep.lock.RLock()
+	defer ep.lock.RUnlock()
+
+	return ep.active
+}
+
+// Close will close all the connections associated with this host.
+func (ep *endpoint) Close() error {
+	if ep.IsClosed() {
+		return nil
+	}
+
+	ep.lock.Lock()
+	idle := ep.idle
+	ep.idle.Init()
+	close(ep.done)
+
+	ep.active -= ep.idle.Len()
+
+	if ep.cond != nil {
+		// everyone waiting for a connection should now wake
+		// and error out since the pool is now closed.
+		ep.cond.Broadcast()
+	}
+
+	// release the lock before we close all the idle connections
+	ep.lock.Unlock()
+
+	for elm := idle.Front(); elm != nil; elm = elm.Next() {
+		elm.Value.(idleConn).conn.Conn.Close()
+	}
+
+	return nil
+}
+
+// IsClosed returns true if the endpoint has been closed.
+// There still might be active connections in flight but they will
+// be closed as they are released.
+func (ep *endpoint) IsClosed() bool {
+	select {
+	case <-ep.done:
+		return true
+	default:
+	}
+
+	return false
+}
+
+// ReturnConn puts the connection back in the pool.
+func (ep *endpoint) ReturnConn(conn *Conn) error {
+	ep.lock.Lock()
+
+	ep.active--
+	if ep.IsClosed() {
+		ep.lock.Unlock()
+		return conn.Close()
+	}
+
+	ep.idle.PushFront(idleConn{
+		conn:      conn,
+		lastUsage: time.Now(),
+	})
+
+	var idled *Conn
+	if m := ep.Pooler.MaxIdlePerHost(); m != 0 && ep.idle.Len() > m {
+		idled = ep.idle.Remove(ep.idle.Back()).(idleConn).conn
+	}
+
+	if idled == nil {
+		if ep.cond != nil {
+			ep.cond.Signal()
+		}
+
+		ep.lock.Unlock()
+		return nil
+	}
+
+	ep.lock.Unlock() // release the lock before we close the
+	return idled.Close()
+}
+
+// RemoveAndClose will close this connection, remove it from the "active" pool
+// and close it. It will not be put in the idle connection pool.
+func (ep *endpoint) RemoveAndClose(conn *Conn) error {
+	ep.lock.Lock()
+	ep.active--
+	ep.lock.Unlock()
+
+	return conn.Conn.Close()
+}
+
+func (ep *endpoint) closeIdleConn(limit time.Time) int {
+	ep.lock.Lock()
+	defer ep.lock.Unlock()
+
+	closed := 0
+
+	// since idle connections are oldest at the back.
+	// close until we find one not idle long enough.
+	for i, n := 0, ep.idle.Len(); i < n; i++ {
+		elm := ep.idle.Back()
+		if elm == nil {
+			break
+		}
+
+		c := elm.Value.(idleConn)
+		if c.lastUsage.After(limit) {
+			break
+		}
+
+		ep.idle.Remove(elm)
+
+		ep.lock.Unlock()
+		c.conn.Close() // release the lock while we close
+		closed++
+
+		ep.lock.Lock()
+		// There can be a quick lock/unlock at the end here
+		// but that will only happen if all idle connections are closed.
+		// Alternately there could be a quick lock/unlock to get n := ep.idle.Len()
+		// but that would happen on every call to this function.
+	}
+
+	return closed
+}
+
+// newConn creates a new connection to this endpoint
+func (ep *endpoint) newConn() (*Conn, error) {
+	socket, err := ep.Pooler.OpenConn(ep.host)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Conn{
+		Endpoint: ep.host,
+		ep:       ep,
+		Conn:     socket,
+	}, nil
+}

--- a/internal/endpoints/endpoint_test.go
+++ b/internal/endpoints/endpoint_test.go
@@ -1,0 +1,113 @@
+package endpoints
+
+import (
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+type testPooler struct {
+	idleTimeout      time.Duration
+	maxActivePerHost int
+	maxIdlePerHost   int
+}
+
+func (tp *testPooler) OpenConn(host string) (io.Closer, error) {
+	return &thrift.TSocket{}, nil
+}
+
+func (tp *testPooler) IdleTimeout() time.Duration {
+	return tp.idleTimeout
+}
+
+func (tp *testPooler) MaxActivePerHost() int {
+	return tp.maxActivePerHost
+}
+
+func (tp *testPooler) MaxIdlePerHost() int {
+	return tp.maxIdlePerHost
+}
+
+func TestEndpointActive(t *testing.T) {
+	tp := &testPooler{}
+	set := NewSet(tp)
+
+	_, err := set.GetConn()
+	if err != ErrNoEndpoints {
+		t.Errorf("incorrect number of endpoints, got %v", err)
+	}
+	set.SetEndpoints([]string{"hosts"})
+
+	c, _ := set.GetConn()
+	if c.Endpoint != "hosts" {
+		t.Errorf("should set endpoint value, got %v", c.Endpoint)
+	}
+
+	if v := set.list[0].ActiveConnections(); v != 1 {
+		t.Errorf("should have 1 active but got %v", v)
+	}
+	c.Release()
+
+	if v := set.list[0].ActiveConnections(); v != 0 {
+		t.Errorf("should have 0 active but got %v", v)
+	}
+
+	c, _ = set.GetConn()
+	if c.Endpoint != "hosts" {
+		t.Errorf("should set endpoint value, got %v", c.Endpoint)
+	}
+	c.Close()
+
+	if v := set.list[0].ActiveConnections(); v != 0 {
+		t.Errorf("should have 0 active but got %v", v)
+	}
+}
+
+func TestEndpointClose(t *testing.T) {
+	tp := &testPooler{
+		maxActivePerHost: 1,
+	}
+	ep := newEndpoint(tp, "host")
+
+	c, _ := ep.GetConn()
+	c.Release()
+	ep.Close()
+
+	// can all closed multiple times.
+	ep.Close()
+	ep.Close()
+	ep.Close()
+
+	if v := ep.IsClosed(); !v {
+		t.Errorf("should be closed, because it is")
+	}
+
+	// This get request must release the lock
+	_, err := ep.GetConn()
+	if err != ErrGetOnClosedEndpoint {
+		t.Errorf("wrong error, got %v", err)
+	}
+}
+
+func TestEndpointGetConn(t *testing.T) {
+	tp := &testPooler{}
+	ep := newEndpoint(tp, "host")
+
+	c1, _ := ep.GetConn()
+	if c1.Endpoint != "host" {
+		t.Errorf("should set endpoint value, got %v", c1.Endpoint)
+	}
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		c1.Release()
+		log.Printf("released")
+	}()
+
+	// This should not deadlock and wait for the first to be released
+	c2, _ := ep.GetConn()
+	c2.Release()
+}

--- a/internal/endpoints/set.go
+++ b/internal/endpoints/set.go
@@ -1,0 +1,160 @@
+package endpoints
+
+import (
+	"errors"
+	"io"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrNoEndpoints is returned when no endpoints are configured or available.
+	ErrNoEndpoints = errors.New("endpoints: no endpoints configured or available")
+
+	// ErrGetOnClosedEndpoint is returned by endpoint.GetConn if the endpoint
+	// has been closed because it was removed from the watch.
+	// This error is retryable.
+	ErrGetOnClosedEndpoint = errors.New("endpoint closed")
+)
+
+// Pooler can be throught of as a parent wrapper to a bunch of endpoints.
+// It defines how connections are opened. And the general behavior of the pool.
+type Pooler interface {
+	// OpenConn creates the network connection to the host.
+	// This could be tcp, udp, higher level thrift, etc.
+	OpenConn(host string) (io.Closer, error)
+
+	IdleTimeout() time.Duration
+	MaxActivePerHost() int
+	MaxIdlePerHost() int
+}
+
+// Set contains a list of endpoints and defines
+// some operation on top of it.
+type Set struct {
+	Pooler Pooler
+	lock   sync.RWMutex
+	list   []*endpoint
+}
+
+// NewSet creates a new endpoint set.
+func NewSet(pooler Pooler) *Set {
+	return &Set{
+		Pooler: pooler,
+	}
+}
+
+// Close will close all the hosts and thus all the connections
+// for all the endpoints.
+func (s *Set) Close() error {
+	s.lock.Lock()
+	list := s.list
+	s.lock.Unlock()
+
+	for _, ep := range list {
+		ep.Close()
+	}
+
+	return nil
+}
+
+// GetConn returns a connection from the endpoint with the current
+// least amount of active connections.
+func (s *Set) GetConn() (*Conn, error) {
+	s.lock.RLock()
+	if len(s.list) == 0 {
+		s.lock.RUnlock()
+		return nil, ErrNoEndpoints
+	}
+
+	// math.MaxInt32, just greater than the practical maximum for active connections
+	min := 1<<31 - 1
+	var minEP *endpoint
+
+	// TODO: would be interesting to implement a min-heap here.
+	for _, ep := range s.list {
+		if ep.IsClosed() {
+			continue
+		}
+
+		if a := ep.ActiveConnections(); a < min {
+			min = a
+			minEP = ep
+		}
+	}
+	s.lock.RUnlock()
+
+	if minEP == nil {
+		return nil, ErrNoEndpoints
+	}
+
+	c, err := minEP.GetConn()
+	if err == ErrGetOnClosedEndpoint {
+		// This is a super tight race condition with the above 5 lines.
+		// TODO: figure out if we should retry? or handle in application code?
+	}
+
+	return c, err
+}
+
+// SetEndpoints will do a smart update of the endpoint lists. New hosts
+// will be added, old ones will be removed.
+func (s *Set) SetEndpoints(hosts []string) (added, removed int) {
+	shuffleHosts(hosts)
+	s.lock.Lock()
+
+	// Remove hosts that are currently in the endpoints list, but shouldn't be.
+	// Is there a cleaner implementation of this?
+	var toRemove []*endpoint
+	for i := len(s.list) - 1; i >= 0; i-- {
+		ep := s.list[i]
+		found := false
+		for _, host := range hosts {
+			if ep.Host() == host {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			toRemove = append(toRemove, s.list[i])
+
+			s.list[i] = s.list[len(s.list)-1]
+			s.list = s.list[:len(s.list)-1]
+		}
+	}
+
+	// Add in hosts that are not currently in the endpoints list.
+	for _, host := range hosts {
+		found := false
+		for _, ep := range s.list {
+			if ep.Host() == host {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			s.list = append(s.list, newEndpoint(s.Pooler, host))
+			added++
+		}
+	}
+
+	s.lock.Unlock()
+
+	for _, e := range toRemove {
+		e.Close()
+	}
+
+	return added, len(toRemove) // return value is used for testing
+}
+
+func shuffleHosts(hosts []string) {
+	// TODO: maybe not recreate the random source everytime.
+	r := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+	for i := len(hosts) - 1; i > 0; i-- {
+		j := r.Intn(i)
+		hosts[i], hosts[j] = hosts[j], hosts[i]
+	}
+}

--- a/internal/endpoints/set_test.go
+++ b/internal/endpoints/set_test.go
@@ -1,0 +1,185 @@
+package endpoints
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSetClose(t *testing.T) {
+	tp := &testPooler{}
+	set := NewSet(tp)
+	set.SetEndpoints([]string{"host1", "host2"})
+
+	c1, _ := set.GetConn()
+	c2, _ := set.GetConn()
+
+	// should be able to call close multiple times.
+	set.Close()
+	set.Close()
+
+	for _, e := range set.list {
+		if !e.IsClosed() {
+			t.Errorf("endpoints should be closed")
+		}
+	}
+
+	// should be able to call close multiple times.
+	c1.Close()
+	c1.Close()
+
+	c2.Close()
+	c2.Close()
+}
+
+func TestSetGetConn(t *testing.T) {
+	tp := &testPooler{}
+	set := NewSet(tp)
+	set.SetEndpoints([]string{"host1", "host2"})
+
+	c1, _ := set.GetConn()
+	c2, _ := set.GetConn()
+
+	if v := set.list[0].ActiveConnections(); v != 1 {
+		t.Errorf("none should be active, set closed, got %v", v)
+	}
+
+	if v := set.list[1].ActiveConnections(); v != 1 {
+		t.Errorf("none should be active, set closed, got %v", v)
+	}
+
+	c1.Close()
+	c2.Close()
+
+	if v := set.list[0].ActiveConnections(); v != 0 {
+		t.Errorf("none should be active, set closed, got %v", v)
+	}
+
+	if v := set.list[1].ActiveConnections(); v != 0 {
+		t.Errorf("none should be active, set closed, got %v", v)
+	}
+}
+
+func TestSetGetConnClosedEndpoint(t *testing.T) {
+	tp := &testPooler{}
+	set := NewSet(tp)
+	set.SetEndpoints([]string{"host"})
+
+	_, err := set.GetConn()
+	if err != nil {
+		t.Errorf("should have server, got %v", err)
+	}
+
+	// close the only endpoint
+	set.list[0].Close()
+	_, err = set.GetConn()
+	if err != ErrNoEndpoints {
+		t.Errorf("should return no endpoints, got %v", err)
+	}
+
+	// close the whole thriftset
+	set.Close()
+	_, err = set.GetConn()
+	if err != ErrNoEndpoints {
+		t.Errorf("should return no endpoints, got %v", err)
+	}
+}
+
+func TestRelease(t *testing.T) {
+	tp := &testPooler{}
+	set := NewSet(tp)
+	set.SetEndpoints([]string{"host1"})
+
+	c1, _ := set.GetConn()
+	c1.Release()
+
+	c2, _ := set.GetConn()
+	if c1 != c2 {
+		t.Errorf("should reuse connections")
+	}
+}
+
+func TestSetSetEndpoints(t *testing.T) {
+	tp := &testPooler{}
+	set := NewSet(tp)
+	set.SetEndpoints([]string{"endpoint"})
+
+	if l := len(set.list); l != 1 {
+		t.Errorf("length of endpoints wrong, got %v", l)
+	}
+
+	// add one host
+	added, removed := set.SetEndpoints([]string{"endpoint", "endpoint2"})
+	if added != 1 {
+		t.Errorf("wrong number added, got %v", added)
+	}
+
+	if removed != 0 {
+		t.Errorf("wrong number removed, got %v", removed)
+	}
+
+	if l := len(set.list); l != 2 {
+		t.Errorf("length of endpoints wrong, got %v", l)
+	}
+
+	// add another host
+	added, removed = set.SetEndpoints([]string{"endpoint", "endpoint2", "endpoint3"})
+	if added != 1 {
+		t.Errorf("wrong number added, got %v", added)
+	}
+
+	if removed != 0 {
+		t.Errorf("wrong number removed, got %v", removed)
+	}
+
+	if l := len(set.list); l != 3 {
+		t.Errorf("length of endpoints wrong, got %v", l)
+	}
+
+	// remove two hosts
+	added, removed = set.SetEndpoints([]string{"endpoint"})
+	if added != 0 {
+		t.Errorf("wrong number added, got %v", added)
+	}
+
+	if removed != 2 {
+		t.Errorf("wrong number removed, got %v", removed)
+	}
+
+	if l := len(set.list); l != 1 {
+		t.Errorf("length of endpoints wrong, got %v", l)
+	}
+
+	if h := set.list[0].Host(); h != "endpoint" {
+		t.Errorf("incorrect host, got %v", h)
+	}
+
+	// add one host
+	added, removed = set.SetEndpoints([]string{"endpoint", "endpoint2"})
+	if added != 1 {
+		t.Errorf("wrong number added, got %v", added)
+	}
+
+	if removed != 0 {
+		t.Errorf("wrong number removed, got %v", removed)
+	}
+
+	// set as one different host
+	added, removed = set.SetEndpoints([]string{"endpoint3"})
+	if added != 1 {
+		t.Errorf("wrong number added, got %v", added)
+	}
+
+	if removed != 2 {
+		t.Errorf("wrong number removed, got %v", removed)
+	}
+}
+
+func TestShuffleHosts(t *testing.T) {
+	original := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	hosts := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	shuffleHosts(hosts)
+
+	if reflect.DeepEqual(hosts, original) {
+		t.Errorf("did not shuffle, got %v", hosts)
+	}
+}

--- a/thriftset/README.md
+++ b/thriftset/README.md
@@ -1,0 +1,107 @@
+go.serversets/thriftset [![Build Status](https://travis-ci.org/strava/go.serversets.png?branch=master)](https://travis-ci.org/strava/go.serversets) [![Godoc Reference](https://godoc.org/github.com/strava/go.serversets?status.png)](https://godoc.org/github.com/strava/go.serversets/thriftset)
+=====================
+
+Package **thriftset** provides "least active request" balancing over a set of endpoints
+provided by [go.serversets](/..). Connections are kept in a pool and reused as needed.
+
+Usage
+-----
+
+	zookeepers := []string{"10.0.1.0", "10.0.5.0", "10.0.9.0"}
+	watch, err := serversets.New(serversets.Production, "service_name", zookeepers).Watch()
+	if err != nil {
+		// This will be a problem connecting to Zookeeper
+		log.Fatalf("Registration error: %v", err)
+	}
+
+	ts := thriftset.New(watch)
+
+	// or using a fixed set of servers, to just use the loadbalancing
+	ts := thriftset.New(fixedset.New([]string{"host1:1234", "host2:1234"}))
+
+	service := New(ts)
+
+	resp, err := service.Find(123)
+	log.Printf("%v %v", resp, err)
+
+The Service object is a helpful way to wrap the thrift interface into something nicer.
+It handles the "checking out" or connections and returning them. This `thriftset` package
+returns a connection to the endpoint with the least amount of of checked out connections.
+
+	// A Service object wraps the thrift interface with helper methods to fetch/update data.
+	type Service struct {
+		set              *thriftset.ThriftSet
+		protocolFactory  thrift.TProtocolFactory
+		transportFactory thrift.TTransportFactory
+	}
+
+	func New(set *thriftset.ThriftSet) (*Service) {
+		return &Service{
+			set:              set,
+			protocolFactory:  thrift.NewTBinaryProtocolFactory(),
+			transportFactory: thrift.NewTFramedTransportFactory(thrift.NewTTransportFactory()),
+		}
+	}
+
+	func (s *Service) Close() error {
+		return s.set.Close()
+	}
+
+	func (s *Service) getClient() (*thriftset.Conn, *sampleservice.SampleServiceClient, error) {
+		conn, err := s.set.GetConn()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if conn.Client == nil {
+			transport := s.transportFactory.GetTransport(conn.Socket)
+			err = transport.Open()
+			if err != nil {
+				return nil, nil, err
+			}
+
+			// The client factory is cached on the client
+			conn.Client = sampleservice.NewSampleServiceClientFactory(transport, s.protocolFactory)
+		}
+
+		return conn, conn.Client.(*sampleservice.SampleServiceClient), nil
+	}
+
+	func (s *Service) releaseClient(conn *thriftset.Conn, err error) error {
+		// do some sort of check to see if this error should close the connection or not.
+		// ie. is it network related, or just a thrift exception
+		if fatalError(err) {
+			conn.Close()
+			return err
+		}
+
+		return conn.Release() // returns the connection back to the pool
+	}
+
+	func (s *Service) Find(id int64) (*Sample, error) {
+		req := sampleservice.NewGetRequest()
+		req.ID = id
+
+		conn, client, err := s.getClient()
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := client.Get(req)
+		err = s.releaseClient(conn, err)
+		if err != nil {
+			return nil, err
+		}
+
+		// convert the thrift object into a "clearer" go type.
+		// Maybe add some validation.
+		return &Sample{
+			ID: id
+			Metadata: resp.Metadata,
+		}, nil
+	}
+
+Potential Improvements and Contributing
+---------------------------------------
+It'd be nice to mark an endpoint as down if it returns too many errors.
+If you'd like, submit a pull request.

--- a/thriftset/thriftset.go
+++ b/thriftset/thriftset.go
@@ -1,0 +1,299 @@
+package thriftset
+
+import (
+	"errors"
+	"io"
+	"time"
+
+	"github.com/strava/go.serversets/internal/endpoints"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/strava/go.statsd"
+)
+
+const (
+	sdConnRequested = "thriftset.conn.requested"
+	sdConnCreated   = "thriftset.conn.created"
+	sdConnCreateErr = "thriftset.conn.create_error"
+	sdConnReleased  = "thriftset.conn.released"
+	sdConnClosed    = "thriftset.conn.closed"
+	sdZKEvent       = "thriftset.zk_event"
+)
+
+// Default values for ThriftSet parameters
+const (
+	DefaultMaxIdlePerHost   = 10
+	DefaultMaxActivePerHost = 10
+	DefaultTimeout          = time.Second
+	DefaultIdleTimeout      = 5 * time.Minute
+)
+
+var (
+	// ErrNoEndpoints is returned when no endpoints are configured or available.
+	ErrNoEndpoints = errors.New("thriftset: no endpoints configured or available")
+
+	// ErrGetOnClosedSet is returned when requesting a connection from a closed thrift set.
+	ErrGetOnClosedSet = errors.New("thriftset: get on closed set")
+
+	// ErrGetOnClosedEndpoint is returned by endpoint.GetConn if the endpoint
+	// has been closed because it was removed from the watch.
+	// This error is retryable.
+	ErrGetOnClosedEndpoint = errors.New("endpoint closed")
+
+	// errMap maps the internal endpoints errors to these exported ones.
+	errMap = map[error]error{
+		endpoints.ErrNoEndpoints:         ErrNoEndpoints,
+		endpoints.ErrGetOnClosedEndpoint: ErrGetOnClosedEndpoint,
+	}
+)
+
+// A Watcher represents how a serverset.Watch is used so we can use the zookeeper kind
+// or a fixed set or stub it out for testing.
+type Watcher interface {
+	Endpoints() []string
+	Event() <-chan struct{}
+	IsClosed() bool
+}
+
+// ThriftSet defines a set of thift connections. It loadbalances over
+// the set of hosts using the "least active connections" strategy.
+type ThriftSet struct {
+	watch Watcher
+
+	LastEvent  time.Time
+	EventCount int
+	StatsD     statsd.Stater
+
+	maxIdlePerHost   int // max idle must be >= max active
+	maxActivePerHost int
+	timeout          time.Duration
+	idleTimeout      time.Duration
+
+	endpoints *endpoints.Set
+
+	// This channel will get an event when zookeeper updates things
+	// calling SetEndpoints will not trigger this type of event.
+	event         chan struct{}
+	watcherClosed chan struct{}
+	done          chan struct{}
+}
+
+// Conn is the connection returned by the pool.
+type Conn struct {
+	thriftset *ThriftSet // just used for statsd at this point, really needed?
+	parent    *endpoints.Conn
+
+	Socket *thrift.TSocket // used to create new clients
+	Client interface{}     // a place to cache thrift clients.
+}
+
+// New creates a new ThriftSet with default parameters.
+func New(watch Watcher) *ThriftSet {
+	ts := &ThriftSet{
+		watch:         watch,
+		event:         make(chan struct{}, 1),
+		watcherClosed: make(chan struct{}, 1),
+
+		StatsD: statsd.NoopClient{},
+
+		maxIdlePerHost:   DefaultMaxIdlePerHost,
+		maxActivePerHost: DefaultMaxActivePerHost,
+		timeout:          DefaultTimeout,
+		idleTimeout:      DefaultIdleTimeout,
+
+		done: make(chan struct{}),
+	}
+
+	ts.endpoints = endpoints.NewSet(ts)
+	ts.resetEndpoints()
+
+	go func() {
+		defer func() {
+			close(ts.watcherClosed) // the Close method waits for this goroutine to quit.
+			watcherClosed()
+		}()
+
+		for {
+			select {
+			case <-ts.done:
+				return
+			case <-watch.Event():
+				ts.StatsD.Count(sdZKEvent, 1.0)
+
+				ts.resetEndpoints()
+				ts.triggerEvent()
+			}
+
+			if watch.IsClosed() {
+				break
+			}
+		}
+	}()
+
+	return ts
+}
+
+// for use during testing. Saw this in the net/http standard lib.
+var watcherClosed = func() {}
+
+// OpenConn creats a new thrift socket for the host. This is used
+// by the endpoints.Set to create connections for a given endpoint.
+// This is part of the endpoints.Pooler interface.
+func (ts *ThriftSet) OpenConn(hostPort string) (io.Closer, error) {
+	ts.StatsD.Count(sdConnCreated)
+
+	socket, err := socketBuilder(hostPort, ts.timeout)
+	if err != nil {
+		ts.StatsD.Count(sdConnCreateErr, 1.0)
+		return nil, err
+	}
+
+	return socket, err
+}
+
+// to allow stubbing for tests
+var socketBuilder = func(hostPort string, timeout time.Duration) (*thrift.TSocket, error) {
+	return thrift.NewTSocketTimeout(hostPort, timeout)
+}
+
+// IdleTimeout returns the timeout for connections to live in the idle pool.
+// This is part of the endpoints.Pooler interface.
+func (ts *ThriftSet) IdleTimeout() time.Duration {
+	return ts.idleTimeout
+}
+
+// SetIdleTimeout sets the amount of time a connection can live in the idle pool.
+func (ts *ThriftSet) SetIdleTimeout(t time.Duration) {
+	ts.idleTimeout = t
+}
+
+// MaxActivePerHost returna the max active connections for a given host.
+// This is part of the endpoints.Pooler interface.
+func (ts *ThriftSet) MaxActivePerHost() int {
+	return ts.maxActivePerHost
+}
+
+// SetMaxActivePerHost sets the max number of active connections to a given endpoint.
+func (ts *ThriftSet) SetMaxActivePerHost(max int) {
+	ts.maxActivePerHost = max
+}
+
+// MaxIdlePerHost returns the max number of idle connections to keep in the pool.
+// This is part of the endpoints.Pooler interface.
+func (ts *ThriftSet) MaxIdlePerHost() int {
+	return ts.maxIdlePerHost
+}
+
+// SetMaxIdlePerHost sets the max number of connections in the idle pool.
+func (ts *ThriftSet) SetMaxIdlePerHost(max int) {
+	ts.maxIdlePerHost = max
+}
+
+// Timeout is the max length for a given request to the thrift service.
+func (ts *ThriftSet) Timeout() time.Duration {
+	return ts.timeout
+}
+
+// SetTimeout sets the thrift request timeout for new connections in the pool.
+// This should be set at startup, as existing/live connections will not be updated
+// with these new values.
+func (ts *ThriftSet) SetTimeout(t time.Duration) {
+	ts.timeout = t
+}
+
+// Event returns the event channel. This channel will get an object
+// whenever something changes with the list of endpoints.
+// Mostly used for testing as this will trigger after all the watch events handling completes.
+func (ts *ThriftSet) Event() <-chan struct{} {
+	return ts.event
+}
+
+// Close releases the resources used by the set. ie. closes all connections.
+// There may still be connections in flight when this function returns.
+func (ts *ThriftSet) Close() error {
+	if ts.IsClosed() {
+		return nil
+	}
+	close(ts.done)
+
+	err := ts.endpoints.Close()
+	<-ts.watcherClosed // wait for the watcher goroutine to quit
+
+	return err
+}
+
+// IsClosed returns true if the set has been closed.
+// There still might be active connections in flight but they will
+// be closed as they are released.
+func (ts *ThriftSet) IsClosed() bool {
+	select {
+	case <-ts.done:
+		return true
+	default:
+	}
+
+	return false
+}
+
+// GetConn will create a connection or return one from the idle list.
+// It will use a host from the Watcher with the least ammount of active connections.
+func (ts *ThriftSet) GetConn() (*Conn, error) {
+
+	if ts.IsClosed() {
+		return nil, ErrGetOnClosedSet
+	}
+
+	ts.StatsD.Count(sdConnRequested)
+
+	c, err := ts.endpoints.GetConn()
+	if err != nil {
+		if v, ok := errMap[err]; ok {
+			return nil, v
+		}
+
+		return nil, err
+	}
+
+	return &Conn{
+		thriftset: ts,
+		parent:    c,
+		Socket:    c.Conn.(*thrift.TSocket),
+		Client:    c.Data,
+	}, nil
+}
+
+// resetEndpoints closes idle connections on old endpoints.
+func (ts *ThriftSet) resetEndpoints() {
+	hosts := ts.watch.Endpoints()
+	ts.endpoints.SetEndpoints(hosts)
+}
+
+// Release puts the connection back in the pool and allows others to use it.
+func (c *Conn) Release() error {
+	c.thriftset.StatsD.Count(sdConnReleased)
+
+	// TODO: this will return an error if the connection
+	// failed to be closed. Is that what we want?
+
+	c.parent.Data = c.Client
+	return c.parent.Release()
+}
+
+// Close does not put this connection back into the pool.
+// This should be called if there is some sort of problem with the connection.
+func (c *Conn) Close() error {
+	c.thriftset.StatsD.Count(sdConnClosed, 1.0)
+	return c.parent.Close()
+}
+
+// triggerEvent will queue up something in the Event channel if there
+// isn't already something there.
+func (ts *ThriftSet) triggerEvent() {
+	ts.EventCount++
+	ts.LastEvent = time.Now()
+
+	select {
+	case ts.event <- struct{}{}:
+	default:
+	}
+}

--- a/thriftset/thriftset_test.go
+++ b/thriftset/thriftset_test.go
@@ -1,0 +1,168 @@
+package thriftset
+
+import (
+	"testing"
+	"time"
+
+	"github.com/strava/go.serversets/fixedset"
+	"github.com/strava/go.serversets/internal/endpoints"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+func TestThriftSet(t *testing.T) {
+	// this will not compile if ThriftSet does not
+	// implement the pooler interface.
+	var _ endpoints.Pooler = New(fixedset.New([]string{}))
+}
+
+func TestThriftSetClose(t *testing.T) {
+	count := 0
+	event := make(chan struct{}, 1)
+
+	watcherClosed = func() {
+		count++
+		event <- struct{}{}
+	}
+
+	ts := New(fixedset.New([]string{"endpoint"}))
+	socketBuilder = func(string, time.Duration) (*thrift.TSocket, error) {
+		return &thrift.TSocket{}, nil
+	}
+
+	c, _ := ts.GetConn()
+	c.Release()
+
+	ts.Close()
+
+	// little event channel to allow the other goroutine to run and quit as it should
+	<-event
+	if count != 1 {
+		t.Error("should close watching goroutine on watcher channel close")
+	}
+
+	// can all closed multiple times.
+	ts.Close()
+	ts.Close()
+	ts.Close()
+
+	if v := ts.IsClosed(); !v {
+		t.Errorf("should not be closed, because it is")
+	}
+
+	// This get request must releases the lock
+	_, err := ts.GetConn()
+	if err != ErrGetOnClosedSet {
+		t.Errorf("wrong error, got %v", err)
+	}
+
+	_, err = ts.GetConn()
+	if err != ErrGetOnClosedSet {
+		t.Errorf("wrong error, got %v", err)
+	}
+
+	// reset
+	watcherClosed = func() {}
+}
+
+func TestThriftSetGetConn(t *testing.T) {
+	socketBuilder = func(string, time.Duration) (*thrift.TSocket, error) {
+		return &thrift.TSocket{}, nil
+	}
+
+	fs := fixedset.New([]string{})
+	ts := New(fs)
+	defer ts.Close()
+
+	_, err := ts.GetConn()
+	if err != ErrNoEndpoints {
+		t.Errorf("incorrect error, got %v", err)
+	}
+
+	fs.SetEndpoints([]string{"endpoint"})
+	<-ts.Event()
+
+	_, err = ts.GetConn()
+	if err != nil {
+		t.Errorf("should have server, got %v", err)
+	}
+}
+
+func TestConn(t *testing.T) {
+	type testStruct struct {
+		Something int
+	}
+
+	fs := fixedset.New([]string{"host"})
+	ts := New(fs)
+	defer ts.Close()
+
+	object := &testStruct{123}
+
+	c, _ := ts.GetConn()
+	c.Client = object
+	c.Release()
+
+	c, _ = ts.GetConn()
+	if c.Client != object {
+		t.Errorf("should have same object in new conn")
+	}
+	c.Release()
+}
+
+func TestConnRelease(t *testing.T) {
+	ts := New(fixedset.New([]string{"endpoint"}))
+	defer ts.Close()
+
+	s1 := &thrift.TSocket{}
+	socketBuilder = func(string, time.Duration) (*thrift.TSocket, error) {
+		return s1, nil
+	}
+
+	c, _ := ts.GetConn()
+	if c.Socket != s1 {
+		t.Errorf("should get correct socket")
+	}
+	c.Release()
+
+	c, _ = ts.GetConn()
+	if c.Socket != s1 {
+		t.Errorf("should still get the same socket")
+	}
+
+	s2 := &thrift.TSocket{}
+	socketBuilder = func(string, time.Duration) (*thrift.TSocket, error) {
+		return s2, nil
+	}
+
+	c, _ = ts.GetConn()
+	if c.Socket != s2 {
+		t.Errorf("should get new second socket because first not released")
+	}
+}
+
+func TestConnClose(t *testing.T) {
+	ts := New(fixedset.New([]string{"endpoint"}))
+	defer ts.Close()
+
+	s1 := &thrift.TSocket{}
+	socketBuilder = func(string, time.Duration) (*thrift.TSocket, error) {
+		return s1, nil
+	}
+
+	c, _ := ts.GetConn()
+	if c.Socket != s1 {
+		t.Errorf("should get correct socket")
+	}
+	c.Close()
+
+	s2 := &thrift.TSocket{}
+	socketBuilder = func(string, time.Duration) (*thrift.TSocket, error) {
+		return s2, nil
+	}
+
+	c, _ = ts.GetConn()
+	if c.Socket != s2 {
+		t.Errorf("should get another socket because first closed and not returned")
+	}
+}


### PR DESCRIPTION
This open sources our thrift services balancing based on endpoints discoverable in zookeeper. It also adds a internal/generic endpoints package that could be used by other things, like http, to do least connections load balancing.

@mlerner please take a look.  

Still need to add a readme with example usage. 