### PR TITLE
Use zookeeper 3.4.6 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - GO15VENDOREXPERIMENT=1
 
 before_install:
-  - wget http://apache.claz.org/zookeeper/zookeeper-3.4.7/zookeeper-3.4.7.tar.gz
+  - wget http://apache.claz.org/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
   - tar -zxvf zookeeper*tar.gz
   - cd zookeeper*
   - cp conf/zoo_sample.cfg conf/zoo.cfg


### PR DESCRIPTION
Zookeeper 3.4.7 was pulled, and travis is failing because of it and 3.4.8 isn't out yet.
Changed back to 3.4.6 which is the current stable version.